### PR TITLE
Add thruster efficiency column to Mission Maneuvers table

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -86,6 +86,9 @@ class ManeuverInput(BaseModel):
     delta_v_mps: Annotated[float, Field(ge=0, description="Delta-V in m/s")]
     thruster_id: UUID
     occurrences: Annotated[int, Field(ge=1, le=10000, description="Number of occurrences")] = 1
+    thruster_efficiency: Annotated[
+        float, Field(ge=0, le=1, description="Thruster efficiency factor (0-1)")
+    ] = 1.0
 
 
 class ManeuverResult(BaseModel):

--- a/backend/app/routers/compute.py
+++ b/backend/app/routers/compute.py
@@ -48,11 +48,12 @@ async def compute_propellant_budget(request: ComputeRequest) -> ComputeResponse:
         thruster_map[str(maneuver.thruster_id)] = thruster
 
         is_biprop = thruster.thruster_type == ThrusterType.CHEMICAL_BIPROP
+        effective_isp = thruster.isp_s * maneuver.thruster_efficiency
         maneuver_specs.append(
             ManeuverSpec(
                 name=maneuver.name,
                 delta_v_mps=maneuver.delta_v_mps,
-                isp_s=thruster.isp_s,
+                isp_s=effective_isp,
                 occurrences=maneuver.occurrences,
                 is_biprop=is_biprop,
                 mixture_ratio_ox_to_fuel=thruster.mixture_ratio_ox_to_fuel if is_biprop else None,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -74,6 +74,7 @@ function App() {
               delta_v_mps: selectedOption?.dv_remaining_to_geo_mps || 1800,
               thruster_id: transferThruster.id,
               occurrences: 1,
+              thruster_efficiency: 1,
             });
           }
 
@@ -86,6 +87,7 @@ function App() {
               delta_v_mps: 50,
               thruster_id: monoThruster.id,
               occurrences: 15,
+              thruster_efficiency: 1,
             });
 
             defaultManeuvers.push({
@@ -95,6 +97,7 @@ function App() {
               delta_v_mps: 2,
               thruster_id: monoThruster.id,
               occurrences: 15,
+              thruster_efficiency: 1,
             });
 
             defaultManeuvers.push({
@@ -104,6 +107,7 @@ function App() {
               delta_v_mps: 11,
               thruster_id: monoThruster.id,
               occurrences: 1,
+              thruster_efficiency: 1,
             });
           }
 
@@ -161,12 +165,13 @@ function App() {
       const result = await api.computeBudget({
         dry_mass_kg: dryMass,
         launch_option_id: selectedLaunchOption,
-        maneuvers: maneuvers.map(({ name, maneuver_type, delta_v_mps, thruster_id, occurrences }) => ({
+        maneuvers: maneuvers.map(({ name, maneuver_type, delta_v_mps, thruster_id, occurrences, thruster_efficiency }) => ({
           name,
           maneuver_type,
           delta_v_mps,
           thruster_id,
           occurrences,
+          thruster_efficiency,
         })),
       });
       setResults(result);
@@ -192,6 +197,7 @@ function App() {
         delta_v_mps: 100,
         thruster_id: defaultThruster.id,
         occurrences: 1,
+        thruster_efficiency: 1,
       },
     ]);
   }, [thrusters]);

--- a/frontend/src/components/ManeuversTable.tsx
+++ b/frontend/src/components/ManeuversTable.tsx
@@ -45,6 +45,7 @@ export function ManeuversTable({
               <th>Count</th>
               <th>Total ΔV</th>
               <th>Thruster</th>
+              <th>Efficiency</th>
               <th style={{ width: '60px' }}></th>
             </tr>
           </thead>
@@ -145,6 +146,21 @@ export function ManeuversTable({
                   </select>
                 </td>
                 <td>
+                  <input
+                    type="number"
+                    value={maneuver.thruster_efficiency}
+                    onChange={(e) =>
+                      onUpdate(maneuver.id, {
+                        thruster_efficiency: parseFloat(e.target.value) || 0,
+                      })
+                    }
+                    min={0}
+                    max={1}
+                    step={0.01}
+                    className="cell-input cell-input-number cell-input-small"
+                  />
+                </td>
+                <td>
                   <button
                     className="btn-danger btn-sm"
                     onClick={() => onDelete(maneuver.id)}
@@ -162,7 +178,7 @@ export function ManeuversTable({
                 Total Delta-V:
               </td>
               <td className="total-value text-mono">{totalDeltaV.toFixed(1)}</td>
-              <td colSpan={2}></td>
+              <td colSpan={3}></td>
             </tr>
           </tfoot>
         </table>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -31,6 +31,7 @@ export interface ManeuverInput {
   delta_v_mps: number;
   thruster_id: string;
   occurrences: number;
+  thruster_efficiency: number;
 }
 
 /** Computed result for a single maneuver */


### PR DESCRIPTION
Adds a configurable efficiency factor (0-1, default 1) per maneuver that scales the thruster's Isp for propellant calculations. Lower efficiency results in higher propellant consumption.

Close #2