### PR TITLE
Add electric xenon thruster type and update default thrusters

### DIFF
--- a/backend/app/data.py
+++ b/backend/app/data.py
@@ -115,20 +115,47 @@ def get_all_launch_options() -> list[LaunchOption]:
 def init_default_thrusters() -> None:
     """Initialize default thrusters if none exist."""
     if not _thrusters:
-        # REA mono-propellant thruster
-        rea_mono = Thruster(
-            name="REA 22N (Mono)",
+        # 5 lbf REA mono-propellant thruster
+        rea_5lbf = Thruster(
+            name="5 lbf REA",
             thruster_type=ThrusterType.CHEMICAL_MONO,
             isp_s=220.0,
             mixture_ratio_ox_to_fuel=None,
         )
-        _thrusters[rea_mono.id] = rea_mono
+        _thrusters[rea_5lbf.id] = rea_5lbf
+
+        # 0.2 lbf REA mono-propellant thruster
+        rea_02lbf = Thruster(
+            name="0.2 lbf REA",
+            thruster_type=ThrusterType.CHEMICAL_MONO,
+            isp_s=220.0,
+            mixture_ratio_ox_to_fuel=None,
+        )
+        _thrusters[rea_02lbf.id] = rea_02lbf
 
         # LAE bi-propellant thruster
-        lae_biprop = Thruster(
-            name="LAE 490N (Biprop)",
+        lae = Thruster(
+            name="LAE",
             thruster_type=ThrusterType.CHEMICAL_BIPROP,
             isp_s=320.0,
             mixture_ratio_ox_to_fuel=0.8,
         )
-        _thrusters[lae_biprop.id] = lae_biprop
+        _thrusters[lae.id] = lae
+
+        # Arcjets mono-propellant thruster
+        arcjets = Thruster(
+            name="Arcjets",
+            thruster_type=ThrusterType.CHEMICAL_MONO,
+            isp_s=580.0,
+            mixture_ratio_ox_to_fuel=None,
+        )
+        _thrusters[arcjets.id] = arcjets
+
+        # HCT electric xenon thruster
+        hct = Thruster(
+            name="HCT",
+            thruster_type=ThrusterType.ELECTRIC_XENON,
+            isp_s=1800.0,
+            mixture_ratio_ox_to_fuel=None,
+        )
+        _thrusters[hct.id] = hct

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -12,6 +12,7 @@ class ThrusterType(str, Enum):
 
     CHEMICAL_MONO = "chemical_mono"
     CHEMICAL_BIPROP = "chemical_biprop"
+    ELECTRIC_XENON = "electric_xenon"
 
 
 class ManeuverType(str, Enum):
@@ -103,6 +104,7 @@ class ManeuverResult(BaseModel):
     propellant_kg: float
     ox_kg: float | None = None
     fuel_kg: float | None = None
+    xenon_kg: float | None = None
     m_before_kg: float
     m_after_kg: float
 

--- a/backend/app/routers/compute.py
+++ b/backend/app/routers/compute.py
@@ -48,6 +48,7 @@ async def compute_propellant_budget(request: ComputeRequest) -> ComputeResponse:
         thruster_map[str(maneuver.thruster_id)] = thruster
 
         is_biprop = thruster.thruster_type == ThrusterType.CHEMICAL_BIPROP
+        is_xenon = thruster.thruster_type == ThrusterType.ELECTRIC_XENON
         effective_isp = thruster.isp_s * maneuver.thruster_efficiency
         maneuver_specs.append(
             ManeuverSpec(
@@ -57,6 +58,7 @@ async def compute_propellant_budget(request: ComputeRequest) -> ComputeResponse:
                 occurrences=maneuver.occurrences,
                 is_biprop=is_biprop,
                 mixture_ratio_ox_to_fuel=thruster.mixture_ratio_ox_to_fuel if is_biprop else None,
+                is_xenon=is_xenon,
             )
         )
 
@@ -101,6 +103,7 @@ async def compute_propellant_budget(request: ComputeRequest) -> ComputeResponse:
                 propellant_kg=calc_result.propellant_kg,
                 ox_kg=calc_result.ox_kg,
                 fuel_kg=calc_result.fuel_kg,
+                xenon_kg=calc_result.xenon_kg,
                 m_before_kg=calc_result.m_before_kg,
                 m_after_kg=calc_result.m_after_kg,
             )

--- a/backend/app/services/prop_budget.py
+++ b/backend/app/services/prop_budget.py
@@ -21,6 +21,7 @@ class ManeuverSpec:
     occurrences: int = 1
     is_biprop: bool = False
     mixture_ratio_ox_to_fuel: float | None = None
+    is_xenon: bool = False
 
 
 @dataclass
@@ -36,6 +37,7 @@ class ManeuverCalcResult:
     m_after_kg: float
     ox_kg: float | None = None
     fuel_kg: float | None = None
+    xenon_kg: float | None = None
 
 
 @dataclass
@@ -149,8 +151,11 @@ def _compute_propellant_given_initial_mass(
         # Compute biprop split if applicable
         ox_kg: float | None = None
         fuel_kg: float | None = None
+        xenon_kg: float | None = None
         if maneuver.is_biprop and maneuver.mixture_ratio_ox_to_fuel is not None:
             fuel_kg, ox_kg = compute_biprop_split(prop_kg, maneuver.mixture_ratio_ox_to_fuel)
+        elif maneuver.is_xenon:
+            xenon_kg = prop_kg
 
         results.append(
             ManeuverCalcResult(
@@ -163,6 +168,7 @@ def _compute_propellant_given_initial_mass(
                 m_after_kg=m_after,
                 ox_kg=ox_kg,
                 fuel_kg=fuel_kg,
+                xenon_kg=xenon_kg,
             )
         )
 

--- a/frontend/src/components/ResultsCard.tsx
+++ b/frontend/src/components/ResultsCard.tsx
@@ -18,10 +18,12 @@ export function ResultsCard({ results }: ResultsCardProps) {
     maneuvers,
   } = results;
 
-  // Calculate totals for biprop
+  // Calculate totals for biprop and xenon
   const totalOx = maneuvers.reduce((sum, m) => sum + (m.ox_kg ?? 0), 0);
   const totalFuel = maneuvers.reduce((sum, m) => sum + (m.fuel_kg ?? 0), 0);
+  const totalXenon = maneuvers.reduce((sum, m) => sum + (m.xenon_kg ?? 0), 0);
   const hasBiprop = maneuvers.some((m) => m.ox_kg !== null);
+  const hasXenon = maneuvers.some((m) => m.xenon_kg !== null);
 
   return (
     <Card title="Results" className="results-card">
@@ -98,6 +100,17 @@ export function ResultsCard({ results }: ResultsCardProps) {
         </div>
       )}
 
+      {/* Xenon Totals */}
+      {hasXenon && (
+        <div className="biprop-summary">
+          <h4>Xenon Totals</h4>
+          <div className="biprop-row">
+            <span>Total Xenon:</span>
+            <span className="text-mono">{totalXenon.toFixed(1)} kg</span>
+          </div>
+        </div>
+      )}
+
       {/* Per-Maneuver Breakdown */}
       <h4 className="breakdown-title">Per-Maneuver Breakdown</h4>
       <div className="breakdown-table-container">
@@ -114,6 +127,7 @@ export function ResultsCard({ results }: ResultsCardProps) {
                   <th>Fuel (kg)</th>
                 </>
               )}
+              {hasXenon && <th>Xenon (kg)</th>}
               <th>Mass Before</th>
               <th>Mass After</th>
             </tr>
@@ -144,6 +158,11 @@ export function ResultsCard({ results }: ResultsCardProps) {
                       {m.fuel_kg !== null ? m.fuel_kg.toFixed(1) : '—'}
                     </td>
                   </>
+                )}
+                {hasXenon && (
+                  <td className="text-mono text-right">
+                    {m.xenon_kg !== null ? m.xenon_kg.toFixed(1) : '—'}
+                  </td>
                 )}
                 <td className="text-mono text-right">
                   {m.m_before_kg.toLocaleString(undefined, {

--- a/frontend/src/components/ThrustersManager.tsx
+++ b/frontend/src/components/ThrustersManager.tsx
@@ -103,7 +103,11 @@ export function ThrustersManager({
               <div className="thruster-name">{thruster.name}</div>
               <div className="thruster-details">
                 <span className="thruster-type">
-                  {thruster.thruster_type === 'chemical_mono' ? 'Mono' : 'Biprop'}
+                  {thruster.thruster_type === 'chemical_mono'
+                    ? 'Mono'
+                    : thruster.thruster_type === 'chemical_biprop'
+                      ? 'Biprop'
+                      : 'Xenon'}
                 </span>
                 <span className="thruster-isp text-mono">
                   Isp: {thruster.isp_s}s
@@ -180,6 +184,7 @@ export function ThrustersManager({
               >
                 <option value="chemical_mono">Monopropellant</option>
                 <option value="chemical_biprop">Bipropellant</option>
+                <option value="electric_xenon">Electric (Xenon)</option>
               </select>
             </div>
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,5 +1,5 @@
 /** Thruster propellant types */
-export type ThrusterType = 'chemical_mono' | 'chemical_biprop';
+export type ThrusterType = 'chemical_mono' | 'chemical_biprop' | 'electric_xenon';
 
 /** Standard maneuver types */
 export type ManeuverType = 'orbit_transfer' | 'nssk' | 'ewsk' | 'disposal' | 'custom';
@@ -45,6 +45,7 @@ export interface ManeuverResult {
   propellant_kg: number;
   ox_kg: number | null;
   fuel_kg: number | null;
+  xenon_kg: number | null;
   m_before_kg: number;
   m_after_kg: number;
 }


### PR DESCRIPTION
Add ELECTRIC_XENON thruster type for xenon-based electric propulsion. Update default thrusters to: 5 lbf REA, 0.2 lbf REA, LAE, Arcjets, and HCT. Track xenon propellant separately in computation results and display xenon totals in the results UI.

Close #4